### PR TITLE
Accelerate with copilot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -107,3 +107,21 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.post("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    # Validate student is currently registered
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student not registered for this activity")
+
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,45 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    # Sports-related activities
+    "Soccer Team": {
+        "description": "Outdoor team practices and interschool matches",
+        "schedule": "Mondays and Thursdays, 4:00 PM - 6:00 PM",
+        "max_participants": 25,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Skills training, scrimmages, and weekend tournaments",
+        "schedule": "Tuesdays and Thursdays, 4:30 PM - 6:00 PM",
+        "max_participants": 20,
+        "participants": ["ava@mergington.edu", "isabella@mergington.edu"]
+    },
+    # Artistic activities
+    "Art Studio": {
+        "description": "Painting, drawing, and mixed-media workshops",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["mia@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Acting exercises, scene work, and school productions",
+        "schedule": "Fridays, 4:00 PM - 6:00 PM",
+        "max_participants": 25,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    # Intellectual activities
+    "Science Club": {
+        "description": "Hands-on experiments, guest lectures, and science fairs",
+        "schedule": "Mondays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["elijah@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Public speaking, argumentation practice, and competitions",
+        "schedule": "Tuesdays, 5:00 PM - 6:30 PM",
+        "max_participants": 12,
+        "participants": ["sophia@mergington.edu", "oliver@mergington.edu"]
     }
 }
 
@@ -62,6 +101,9 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+# Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,11 +20,32 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        // Create participants list HTML
+        let participantsHTML = "";
+        if (details.participants.length > 0) {
+          participantsHTML = `
+            <div class="participants-section">
+              <strong>Participants:</strong>
+              <ul class="participants-list">
+                ${details.participants.map(email => `<li>${email}</li>`).join("")}
+              </ul>
+            </div>
+          `;
+        } else {
+          participantsHTML = `
+            <div class="participants-section">
+              <strong>Participants:</strong>
+              <p class="participants-none">No participants yet.</p>
+            </div>
+          `;
+        }
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          ${participantsHTML}
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -13,6 +13,11 @@ document.addEventListener("DOMContentLoaded", () => {
       // Clear loading message
       activitiesList.innerHTML = "";
 
+      // Reset select options (keep the first placeholder)
+      while (activitySelect.options.length > 1) {
+        activitySelect.remove(1);
+      }
+
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
@@ -20,14 +25,23 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
-        // Create participants list HTML
+        // Create participants list HTML (with delete button per participant)
         let participantsHTML = "";
         if (details.participants.length > 0) {
           participantsHTML = `
             <div class="participants-section">
               <strong>Participants:</strong>
               <ul class="participants-list">
-                ${details.participants.map(email => `<li>${email}</li>`).join("")}
+                ${details.participants
+                  .map(
+                    (email) => `
+                      <li class="participant-item">
+                        <span class="participant-email">${email}</span>
+                        <button class="delete-icon" title="Unregister" aria-label="Unregister ${email}" data-activity="${name}" data-email="${email}">✕</button>
+                      </li>
+                    `
+                  )
+                  .join("")}
               </ul>
             </div>
           `;
@@ -83,6 +97,8 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        // Refresh list so changes are visible immediately
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -99,6 +115,40 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  // Handle unregister clicks using event delegation
+  activitiesList.addEventListener("click", async (event) => {
+    const btn = event.target.closest(".delete-icon");
+    if (!btn) return;
+
+    const activity = btn.getAttribute("data-activity");
+    const email = btn.getAttribute("data-email");
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
+        { method: "POST" }
+      );
+
+      const result = await response.json();
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        // Refresh activities list
+        fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -142,3 +142,32 @@ footer {
   padding: 20px;
   color: #666;
 }
+
+.participants-section {
+  margin-top: 12px;
+  padding: 10px;
+  background-color: #eef2ff;
+  border-radius: 4px;
+  border: 1px solid #c5cae9;
+}
+
+.participants-section strong {
+  color: #3949ab;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.participants-list {
+  list-style-type: disc;
+  margin-left: 20px;
+  margin-bottom: 0;
+  color: #333;
+  font-size: 15px;
+}
+
+.participants-none {
+  color: #888;
+  font-style: italic;
+  margin-left: 2px;
+  margin-bottom: 0;
+}

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -158,11 +158,37 @@ footer {
 }
 
 .participants-list {
-  list-style-type: disc;
-  margin-left: 20px;
+  list-style: none;
+  padding-left: 0;
+  margin-left: 0;
   margin-bottom: 0;
   color: #333;
   font-size: 15px;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border: 1px solid #c5cae9;
+  border-radius: 14px;
+  background: #fff;
+  margin: 4px 0;
+  width: fit-content;
+}
+
+.delete-icon {
+  background: transparent;
+  color: #c62828;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 2px 6px;
+}
+.delete-icon:hover {
+  color: #b71c1c;
 }
 
 .participants-none {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,78 @@
+import sys
+from pathlib import Path
+
+# Ensure the src directory is on the path so we can import the app module
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from fastapi.testclient import TestClient  # type: ignore
+from app import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_root_redirect():
+    response = client.get("/", allow_redirects=False)
+    assert response.status_code in (307, 302)
+    assert response.headers.get("location") == "/static/index.html"
+
+
+def test_get_activities():
+    response = client.get("/activities")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, dict)
+    # Spot-check a known activity structure
+    assert "Chess Club" in data
+    chess = data["Chess Club"]
+    assert "description" in chess
+    assert "participants" in chess and isinstance(chess["participants"], list)
+
+
+def test_signup_and_unregister_flow():
+    activity = "Chess Club"
+    email = "autotest_student@mergington.edu"
+
+    # Ensure cleanup in case of previous run leftovers
+    client.post(f"/activities/{activity}/unregister", params={"email": email})
+
+    # Sign up should succeed
+    r_signup = client.post(f"/activities/{activity}/signup", params={"email": email})
+    assert r_signup.status_code == 200
+    assert "Signed up" in r_signup.json().get("message", "")
+
+    # Verify presence
+    r_get = client.get("/activities")
+    assert r_get.status_code == 200
+    assert email in r_get.json()[activity]["participants"]
+
+    # Unregister should succeed
+    r_unreg = client.post(f"/activities/{activity}/unregister", params={"email": email})
+    assert r_unreg.status_code == 200
+    assert "Unregistered" in r_unreg.json().get("message", "")
+
+    # Verify removal
+    r_get2 = client.get("/activities")
+    assert r_get2.status_code == 200
+    assert email not in r_get2.json()[activity]["participants"]
+
+
+def test_signup_duplicate_rejected():
+    activity = "Chess Club"
+    # Use an existing seeded participant from app.py
+    existing_email = "michael@mergington.edu"
+    r = client.post(f"/activities/{activity}/signup", params={"email": existing_email})
+    assert r.status_code == 400
+    assert "already" in r.json().get("detail", "").lower()
+
+
+def test_unregister_when_not_registered_rejected():
+    activity = "Chess Club"
+    email = "not_registered_yet@mergington.edu"
+    # Make sure it's not registered
+    client.post(f"/activities/{activity}/unregister", params={"email": email})
+    r = client.post(f"/activities/{activity}/unregister", params={"email": email})
+    assert r.status_code == 400
+    assert "not registered" in r.json().get("detail", "").lower()


### PR DESCRIPTION
This pull request adds support for unregistering students from activities, enhances the frontend to display and manage participants for each activity, and introduces backend validation to prevent duplicate signups and improper unregistrations. It also includes new tests to verify signup and unregister workflows. The changes are grouped below by theme.

**Backend functionality and validation:**

* Added an `/activities/{activity_name}/unregister` endpoint in `app.py` to allow students to be removed from activities, with validation to ensure students are only unregistered if currently registered.
* Improved signup validation to prevent students from signing up for the same activity more than once.

**Frontend participant management and UI:**

* Enhanced the activities list in `app.js` to show participants for each activity, including a delete button next to each participant for easy unregistering.
* Implemented frontend logic to handle unregistering a participant via the delete button, updating the UI immediately after changes. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R121-R154) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R100-R101)
* Added new CSS styles for participant sections and delete buttons to improve the visual presentation of participant management.

**Testing improvements:**

* Added comprehensive tests in `test_app.py` to verify activity signup, unregister, duplicate signup rejection, and unregister rejection when not registered.

**Activity data expansion:**

* Added several new activities to the `activities` dictionary in `app.py`, including sports, arts, and intellectual clubs, each with sample participants.